### PR TITLE
sync 配置文件保存路径

### DIFF
--- a/src/utils/help.js
+++ b/src/utils/help.js
@@ -171,6 +171,10 @@ module.exports = (inputs) => ({
     }, {
       name: 'trigger',
       desc: 'only sync trigger.'
+    }],
+    args: [{
+      name: '--save <filePath>',
+      desc: 'Sync the configuration file save path.'
     }]
   },
   invoke: {


### PR DESCRIPTION
sync 配置保存交互修改：
- s sync -t  abc.yml :
配置会覆盖 abc.yml， 生成一个 ./.s/abc.[projectName].source_config.yml 的缓存文件【内容同原来的 abc】

- s sync -t  abc.yml --save  a.yaml :
 abc.yml 文件不变， 生成一个 ./.s/abc.[projectName].source_config.yml 的缓存文件